### PR TITLE
HTML-escaping of xss payload in optional_message field

### DIFF
--- a/src/web/spark-form.jsp
+++ b/src/web/spark-form.jsp
@@ -8,6 +8,7 @@
 <%@ page import="org.apache.commons.fileupload.DiskFileUpload"%>
 <%@ page import="java.util.List"%>
 <%@ page import="org.apache.commons.fileupload.FileUploadException"%>
+<%@ page import="org.apache.commons.text.StringEscapeUtils"%>
 <%@ page import="org.jivesoftware.util.Log"%>
 <%@ page import="org.apache.commons.fileupload.FileItem"%>
 <%@ page import="java.util.Iterator"%>
@@ -331,7 +332,7 @@
     <tbody>
         <tr>
             <td>
-                <textarea name="optionalMessage" cols="40" rows="3" wrap="virtual"><%= optionalMessage%></textarea>
+                <textarea name="optionalMessage" cols="40" rows="3" wrap="virtual"><%= StringEscapeUtils.escapeHtml4(optionalMessage)%></textarea>
 
             </td>
         </tr>


### PR DESCRIPTION
### 📊 Metadata *

#### Bounty URL: https://www.huntr.dev/bounties/1-other-openfire-clientControl-plugin/

### ⚙️ Description *

In the page showing the Spark version of the plugin, the (dangerous)  characters of the comment that can cause an XSS are transformed in a way the are not dangerous any more

### 💻 Technical Description *

The XSS payload was insertend in the html template without escaping the dangerous characters. The fix is the followings: in the apache.commons.text (already present in the pom of the project) there is a the method that HTML-escapes dangerous characters; using the method to render in a safe way the optional comment in the html page  the the payload doesn't work any more

### 🐛 Proof of Concept (PoC) *

The video shows how the payload triggers the XSS evry time the page is loaded. The version of the plugin is the one on the marketplace


https://user-images.githubusercontent.com/62958189/105390085-f4be1300-5c18-11eb-8525-c1a31c10373c.mp4



### 🔥 Proof of Fix (PoF) *

The video shows that the payload doesn't trigger XSS anymore thantk to escaping some characters. The version of the plugin is 2.1.7-SNAPSHOT.


https://user-images.githubusercontent.com/62958189/105390162-043d5c00-5c19-11eb-8042-cbcf6d5dfd4b.mp4



### 👍 User Acceptance Testing (UAT)

After the fix, the page is still working correctly as before the fix and the XSS is not triggered anymore


